### PR TITLE
Fix race condition with jobs

### DIFF
--- a/signal_repeater_block.py
+++ b/signal_repeater_block.py
@@ -1,25 +1,26 @@
 from collections import defaultdict
 from copy import copy
-from datetime import timedelta
 from nio import Block
 from nio.block import input
 from nio.block.mixins import GroupBy
 from nio.modules.scheduler import Job
 from nio.properties import VersionProperty, IntProperty, TimeDeltaProperty
+from threading import Lock
 
 
 @input('repeat', default=True, order=1)
 @input('cancel', order=2)
 class SignalRepeater(GroupBy, Block):
 
-    version = VersionProperty('0.1.0')
+    version = VersionProperty('0.1.1')
     max_repeats = IntProperty(title='Max Repeats', default=-1)
     interval = TimeDeltaProperty(
-        title='Repeat Interval', default=timedelta(seconds=10))
+        title='Repeat Interval', default={'seconds': 10})
 
     def configure(self, context):
         super().configure(context)
         self.notifications = defaultdict(dict)
+        self._group_locks = defaultdict(Lock)
 
     def stop(self):
         for group in copy(self.notifications):
@@ -39,10 +40,13 @@ class SignalRepeater(GroupBy, Block):
             return
         if len(signals) == 0:
             return
-        self._cancel_group_job(group)
         signal = signals[-1]
         repeats_remaining = self.max_repeats(signal)
-        if repeats_remaining != 0:
+        with self._group_locks[group]:
+            self._cancel_group_job(group)
+            if repeats_remaining == 0:
+                # They don't want to repeat, ignore
+                return
             self.logger.debug("Setting up repeat for group {}".format(group))
             self.notifications[group]['signal'] = signal
             self.notifications[group]['num_remaining'] = repeats_remaining
@@ -53,12 +57,13 @@ class SignalRepeater(GroupBy, Block):
                 group=group)
 
     def notify_group(self, group):
-        notification = self.notifications[group]
-        if notification['num_remaining'] != 0:
-            notification['num_remaining'] -= 1
-            self.logger.debug(
-                "Notifying signal for group {}, {} remaining".format(
-                    group, notification['num_remaining']))
-            self.notify_signals([notification['signal']])
-        else:
-            self._cancel_group_job(group)
+        with self._group_locks[group]:
+            notification = self.notifications[group]
+            if notification.get('num_remaining', 0) != 0:
+                notification['num_remaining'] -= 1
+                self.logger.debug(
+                    "Notifying signal for group {}, {} remaining".format(
+                        group, notification['num_remaining']))
+                self.notify_signals([notification['signal']])
+            else:
+                self._cancel_group_job(group)


### PR DESCRIPTION
Previously, if the timing of your repeat interval lined up with the timing of incoming signals the block would get some weird behavior. Duplicate jobs, missing keys in the notifications dictionary, etc. This locks around modifications to a group's notification interval which removes these race conditions.